### PR TITLE
including example GIFs/Images for each research area

### DIFF
--- a/_includes/area.html
+++ b/_includes/area.html
@@ -1,5 +1,11 @@
 <div class="area">
     <h1>{{ area.title }}</h1>
+    <div class="area-images-container">
+        {% assign pubs = site.data.pubs | where: 'tags', area.tag %}
+        {% for pub in pubs limit:3%}
+            <img src="{{pub.img}}" class="area-images"/>
+        {% endfor %}
+    </div>
     <p class="area-blurb">{{ area.blurb }}</p>
     <details class="area-pubs">
         <summary style="display: list-item;"><b>Relevant Publications</b></summary>

--- a/css/main.css
+++ b/css/main.css
@@ -402,6 +402,17 @@ footer .theme-by {
   margin-bottom: 30px;
 }
 
+.area-images-container{
+  text-align: center;
+}
+
+
+.area-images{
+  width: auto;
+  height: 200px;
+  max-width: 400px;
+}
+
 .blog-tags a {
   color: {{ site.link-col }};
   text-decoration: none;


### PR DESCRIPTION
This PR includes support to view images/GIFs for each research area in this page. Here is a summary of the changes:
1. Each research area section now has images/GIFs of some of the papers in that area.
2. The `css/main.css` has been modified to center the images in each <div> element.
3. There is a cap on the maximum height and width of each image, so that there is some uniformity while viewing them.

Here's a screenshot of how this change looks:

![image](https://user-images.githubusercontent.com/16378754/223305604-326da07e-d726-41a1-bcab-b4779f2a38a3.png)
